### PR TITLE
Ex3

### DIFF
--- a/ex3-thread-queue/main.py
+++ b/ex3-thread-queue/main.py
@@ -1,0 +1,1 @@
+print("Init commit")

--- a/ex3-thread-queue/main.py
+++ b/ex3-thread-queue/main.py
@@ -1,1 +1,49 @@
-print("Init commit")
+import threading
+from queue import Queue
+import time
+
+# limit the number of jobs each thread can execute in its lifetime
+# When the thread has finished that many jobs it will quit 
+# and the main thread will create a new worker thread
+MAX_RUNNING_THREADS = 5
+THREAD_JOB_LIMIT = 1
+
+q = Queue()
+
+def threadJob(num):
+    # when this exits, the print_lock is released
+    print(f"Thread {num} running")
+    time.sleep(num)
+
+def threadHandler():
+    counter = 0 # to keep track of job limit
+    while not q.empty() and counter < THREAD_JOB_LIMIT:
+        # get the job from the front of the queue
+        threadJob(q.get())
+        q.task_done()
+        counter += 1
+
+def main():
+    # Add jobs to queue
+    for job in range(0,25):
+        q.put(job)
+
+    # create 5 initial threads
+    active_threads = [threading.Thread(target=threadHandler) for i in range(MAX_RUNNING_THREADS)]
+
+    #start them
+    for thread in active_threads:
+        thread.start()
+
+    # check whenever the queue is not empty
+    while not q.empty():
+        for thread in active_threads:
+            # if a thread finished his lifetime, create a new one
+            if not thread.is_alive():
+                active_threads.remove(thread)
+                t = threading.Thread(target=threadHandler)
+                t.start()
+                active_threads.append(t)
+
+if __name__ == "__main__":
+    main()

--- a/ex3-thread-queue/main.py
+++ b/ex3-thread-queue/main.py
@@ -2,15 +2,15 @@ import threading
 from queue import Queue
 import time
 
-'''
-ThreadQueue class limits the amount of running threads and the lifespan of each one
-by keeping track of how many 'jobs' each thread executed, after X jobs, the thread
-dies and the main thread will create a new thread to continue executing the jobs.
-'''
 class ThreadQueue:
-    def __init__(self,MAX_RUNNING_THREADS,THREAD_JOB_LIMIT):
-        self.MAX_RUNNING_THREADS = MAX_RUNNING_THREADS
-        self.THREAD_JOB_LIMIT = THREAD_JOB_LIMIT
+    '''
+    ThreadQueue class limits the amount of running threads and the lifespan of each one
+    by keeping track of how many 'jobs' each thread executed, after X jobs, the thread
+    dies and the main thread will create a new thread to continue executing the jobs.
+    '''
+    def __init__(self,max_running_threads,thread_job_limit):
+        self.MAX_RUNNING_THREADS = max_running_threads
+        self.THREAD_JOB_LIMIT = thread_job_limit
 
         self.queue = Queue()
         self.active_threads = []
@@ -29,23 +29,18 @@ class ThreadQueue:
             counter += 1
 
     def create_jobs(self,numbers_of_jobs):
-
         for job in range(0,numbers_of_jobs):
             self.queue.put(job)
 
     def _start_threads(self):
-
         for thread in self.active_threads:
             thread.start()
 
     def run_threads(self):
-        """This function is responsible for new threads creation when a thread
+        """
+        This function is responsible for new threads creation when a thread
             finished his lifespan, this is done by constantly checking 
             the jobs queue and the lifespan of each thread.
-        Args:
-            None
-        Returns:
-            None
         """
         #create 5 initial threads
         self.active_threads = [threading.Thread(target=self._threadHandler) for _ in range(self.MAX_RUNNING_THREADS)]

--- a/ex3-thread-queue/main.py
+++ b/ex3-thread-queue/main.py
@@ -2,48 +2,73 @@ import threading
 from queue import Queue
 import time
 
-# limit the number of jobs each thread can execute in its lifetime
-# When the thread has finished that many jobs it will quit 
-# and the main thread will create a new worker thread
-MAX_RUNNING_THREADS = 5
-THREAD_JOB_LIMIT = 1
+'''
+ThreadQueue class limits the amount of running threads and the lifespan of each one
+by keeping track of how many 'jobs' each thread executed, after X jobs, the thread
+dies and the main thread will create a new thread to continue executing the jobs.
+'''
+class ThreadQueue:
+    def __init__(self,MAX_RUNNING_THREADS,THREAD_JOB_LIMIT):
+        self.MAX_RUNNING_THREADS = MAX_RUNNING_THREADS
+        self.THREAD_JOB_LIMIT = THREAD_JOB_LIMIT
 
-q = Queue()
+        self.queue = Queue()
+        self.active_threads = []
+        
+    def _threadJob(self,num):
+        print(f"Thread {num} running")
+        time.sleep(num)
 
-def threadJob(num):
-    # when this exits, the print_lock is released
-    print(f"Thread {num} running")
-    time.sleep(num)
+    def _threadHandler(self):
+        counter = 0 # to keep track of job limit
 
-def threadHandler():
-    counter = 0 # to keep track of job limit
-    while not q.empty() and counter < THREAD_JOB_LIMIT:
-        # get the job from the front of the queue
-        threadJob(q.get())
-        q.task_done()
-        counter += 1
+        while not self.queue.empty() and counter < self.THREAD_JOB_LIMIT:
+            # get the job from the front of the queue
+            self._threadJob(self.queue.get())
+            self.queue.task_done()
+            counter += 1
+
+    def create_jobs(self,numbers_of_jobs):
+
+        for job in range(0,numbers_of_jobs):
+            self.queue.put(job)
+
+    def _start_threads(self):
+
+        for thread in self.active_threads:
+            thread.start()
+
+    def run_threads(self):
+        """This function is responsible for new threads creation when a thread
+            finished his lifespan, this is done by constantly checking 
+            the jobs queue and the lifespan of each thread.
+        Args:
+            None
+        Returns:
+            None
+        """
+        #create 5 initial threads
+        self.active_threads = [threading.Thread(target=self._threadHandler) for _ in range(self.MAX_RUNNING_THREADS)]
+
+        while not self.queue.empty():
+            # while there are more jobs
+            for thread in self.active_threads:
+                # if a thread finished his lifetime, create a new one
+                if not thread.is_alive():
+                    self.active_threads.remove(thread)
+                    t = threading.Thread(target=self._threadHandler)
+                    t.start()
+                    self.active_threads.append(t)
 
 def main():
-    # Add jobs to queue
-    for job in range(0,25):
-        q.put(job)
+    MAX_RUNNING_THREADS = 5
+    THREAD_JOB_LIMIT = 1
+    JOBS = 25
 
-    # create 5 initial threads
-    active_threads = [threading.Thread(target=threadHandler) for i in range(MAX_RUNNING_THREADS)]
+    thread_queue = ThreadQueue(MAX_RUNNING_THREADS,THREAD_JOB_LIMIT)
+    thread_queue.create_jobs(JOBS)
+    thread_queue.run_threads()
 
-    #start them
-    for thread in active_threads:
-        thread.start()
-
-    # check whenever the queue is not empty
-    while not q.empty():
-        for thread in active_threads:
-            # if a thread finished his lifetime, create a new one
-            if not thread.is_alive():
-                active_threads.remove(thread)
-                t = threading.Thread(target=threadHandler)
-                t.start()
-                active_threads.append(t)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
- Each thread has a job limit of 1 (can be changed with the `THREAD_JOB_LIMIT` variable).
- Whenever a thread finished the jobs, it quits and the main thread creates a new thread if there are more jobs.
- By default there are 5 max threads and 25 jobs to be done.
- The `threadHandler()` function is used to handle a thread by pulling the next job from the queue and executing it with `threadJob(num)`.